### PR TITLE
refactor: 召回引擎改为同步批量写入，带反压与重试

### DIFF
--- a/src/main/java/com/aliyun/openservices/pairec/recallengine/RecallEngineClient.java
+++ b/src/main/java/com/aliyun/openservices/pairec/recallengine/RecallEngineClient.java
@@ -445,8 +445,12 @@ public class RecallEngineClient {
                         flushBufferLocked();
                     } catch (InterruptedException e) {
                         logger.warn("{} interrupted, flushing remaining data before exit", threadName);
-                        Thread.currentThread().interrupt();
+                        // Flush before re-asserting the interrupt: the whole
+                        // point of this flush is to save the last rows, and an
+                        // already-interrupted thread risks having its HTTP call
+                        // aborted underneath it.
                         flushBufferLocked();
+                        Thread.currentThread().interrupt();
                         break;
                     } finally {
                         writeLock.unlock();

--- a/src/main/java/com/aliyun/openservices/pairec/recallengine/RecallEngineClient.java
+++ b/src/main/java/com/aliyun/openservices/pairec/recallengine/RecallEngineClient.java
@@ -7,27 +7,34 @@ import org.slf4j.LoggerFactory;
 
 import java.nio.charset.StandardCharsets;
 import java.util.*;
-import java.util.concurrent.*;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * RecallEngine Client.
- * - recall: Synchronous
- * - write: Asynchronous (Buffered & Batched)
+ * <ul>
+ *   <li>recall: synchronous</li>
+ *   <li>write: synchronous, buffered and batched</li>
+ * </ul>
+ *
+ * <p>Rows handed to {@link #write} are buffered in memory. Once the buffer
+ * reaches {@code batchSize} the HTTP request is issued <em>on the calling
+ * thread</em>. The caller is therefore paced by the actual write throughput of
+ * the backend, which propagates backpressure to the producer (e.g. a Flink
+ * sink) and keeps the buffer from growing without bound.
  */
 public class RecallEngineClient {
     public static final Logger logger = LoggerFactory.getLogger(RecallEngineClient.class);
 
     private static final MediaType JSON = MediaType.get("application/json; charset=utf-8");
     private static final int DEFAULT_TIMEOUT_MS = 500;
-    // JVM-wide counter so async writer thread names stay unique across
-    // multiple RecallEngineClient instances (e.g. Flink parallel sub-tasks
-    // sharing one TaskManager).
-    private static final AtomicInteger ASYNC_WRITER_THREAD_COUNTER = new AtomicInteger();
+    // JVM-wide counter so flush timer thread names stay unique across multiple
+    // RecallEngineClient instances (e.g. Flink parallel sub-tasks sharing one
+    // TaskManager).
+    private static final AtomicInteger FLUSH_TIMER_THREAD_COUNTER = new AtomicInteger();
 
-    // --- Original Fields ---
     private String endpoint;
     private String username;
     private String password;
@@ -37,29 +44,20 @@ public class RecallEngineClient {
     private String authCache;
     private ObjectMapper objectMapper;
 
-    // --- Async Write Infrastructure ---
+    // --- Write buffer ---
     private final List<WriteItem> writeData = new ArrayList<>();
     private final ReentrantLock writeLock = new ReentrantLock();
     private final Condition writeCondition = writeLock.newCondition();
-    private volatile ExecutorService writeExecutor;
     private volatile boolean running = true;
-    private volatile Thread asyncWriteThread;
+    private volatile Thread flushTimerThread;
 
-    // Async Configs (Defaults)
-    private int batchSize = 20;       // Flush when buffer reaches this size
-    private long flushIntervalMs = 50; // Or every 50ms
-    private long flushTimeoutMs = 10000; // Max time writeFlush() waits for an in-flight HTTP batch
-    // Default sized for I/O-bound HTTP work: 2x cores, capped to avoid runaway
-    // allocation on big hosts and bounded below to keep ≥2 workers on tiny ones.
-    // Flink users sharing a TaskManager across slots should override this
-    // explicitly via withWriteThreadPoolSize().
-    private int writeThreadPoolSize = Math.min(32,
-            Math.max(2, 2 * Runtime.getRuntime().availableProcessors()));
-    // Bounded executor task queue capacity. When full, the configured
-    // RejectedExecutionHandler (CallerRunsPolicy by default) makes the
-    // submitting thread run the task itself, providing natural backpressure
-    // instead of unbounded memory growth.
-    private int writeQueueCapacity = 1000;
+    // Flush when the buffer reaches this many rows; also the row cap of a
+    // single HTTP request, so a traffic burst cannot be coalesced into one
+    // oversized body.
+    private int batchSize = 200;
+    // Flush whatever is buffered after this long, so low-traffic streams do not
+    // sit in the buffer waiting for a full batch.
+    private long flushIntervalMs = 50;
 
     /**
      * Create a new RecallEngineClient
@@ -103,63 +101,34 @@ public class RecallEngineClient {
         return this;
     }
 
-    // Async Write Configs
+    /**
+     * Configure the write batch size: the buffer is flushed as soon as it holds
+     * this many rows, and no single HTTP request carries more than this many
+     * rows.
+     *
+     * @param batchSize rows per batch (default: 200)
+     * @return this client for method chaining
+     */
     public RecallEngineClient withBatchSize(int batchSize) {
         if (batchSize <= 0) throw new IllegalArgumentException("Batch size must be positive");
         this.batchSize = batchSize;
         return this;
     }
 
+    /**
+     * Configure how long buffered rows may wait before being flushed even
+     * though the buffer has not reached {@code batchSize}.
+     *
+     * @param flushIntervalMs flush interval in milliseconds (default: 50)
+     * @return this client for method chaining
+     */
     public RecallEngineClient withFlushInterval(long flushIntervalMs) {
         if (flushIntervalMs <= 0) throw new IllegalArgumentException("Flush interval must be positive");
         this.flushIntervalMs = flushIntervalMs;
         return this;
     }
 
-    /**
-     * Configure the maximum time {@link #writeFlush()} will wait for the
-     * pending HTTP write batch to complete before giving up.
-     * <p>
-     * The flush HTTP request is executed outside the buffer lock; this timeout
-     * only bounds how long callers (e.g. {@link #close()} or a Flink Sink
-     * checkpoint) are willing to wait. On timeout the in-flight future is
-     * cancelled and the call returns; data already submitted to the executor
-     * may still be sent best-effort.
-     *
-     * @param flushTimeoutMs flush timeout in milliseconds (default: 10000)
-     * @return this client for method chaining
-     */
-    public RecallEngineClient withFlushTimeoutMs(long flushTimeoutMs) {
-        if (flushTimeoutMs <= 0) throw new IllegalArgumentException("Flush timeout must be positive");
-        this.flushTimeoutMs = flushTimeoutMs;
-        return this;
-    }
-
-    public RecallEngineClient withWriteThreadPoolSize(int poolSize) {
-        if (poolSize <= 0) throw new IllegalArgumentException("Thread pool size must be positive");
-        this.writeThreadPoolSize = poolSize;
-        return this;
-    }
-
-    /**
-     * Configure the bounded queue capacity used by the async write executor.
-     * <p>
-     * When the queue is full, the executor falls back to
-     * {@link java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy} so that
-     * the submitting thread executes the task inline. This propagates
-     * backpressure to producers instead of dropping data or growing memory
-     * without bound.
-     *
-     * @param capacity queue capacity (default: 1000)
-     * @return this client for method chaining
-     */
-    public RecallEngineClient withWriteQueueCapacity(int capacity) {
-        if (capacity <= 0) throw new IllegalArgumentException("Write queue capacity must be positive");
-        this.writeQueueCapacity = capacity;
-        return this;
-    }
-
-    // ==================== Recall (Synchronous - Unchanged) ====================
+    // ==================== Recall (Synchronous) ====================
 
     public RecallResponse recall(RecallRequest request) throws RecallEngineException {
         if (retryTimes > 0) {
@@ -212,7 +181,7 @@ public class RecallEngineClient {
                     } catch (Exception e) {
                         logger.debug("Failed to parse error response", e);
                     }
-                    throw new RecallEngineException(errorMsg);
+                    throw new RecallEngineException(errorMsg, response.code());
                 }
 
                 Record record = RecordUtils.unserializeRecord(responseBytes);
@@ -225,28 +194,27 @@ public class RecallEngineClient {
         }
     }
 
-    // ==================== Write (Asynchronous) ====================
+    // ==================== Write (Synchronous, Buffered) ====================
 
     /**
-     * Make an ASYNC write request.
-     * Data is buffered and sent in batches by a background thread.
-     * This method returns immediately.
+     * Buffer rows for writing and, once a full batch has accumulated, send it
+     * synchronously on the calling thread.
      *
-     * Signature matches the original synchronous version.
+     * <p>The returned {@link WriteResponse} acknowledges buffering, not
+     * server-side persistence: a batch that fails every retry is logged and
+     * dropped so that the producer keeps running.
      */
     public WriteResponse write(String instanceId, String table, WriteRequest request) {
         // Fail fast if the client has already been closed. Without this check,
-        // data would be added to the buffer after close() drained it, with no
-        // background thread or executor to consume it (silent data loss).
+        // data would be added to the buffer after close() drained it, with
+        // nothing left to flush it (silent data loss).
         if (!running) {
             throw new IllegalStateException(
                     "RecallEngineClient is closed; cannot accept new writes");
         }
 
-        // 1. Start background thread if needed
-        startAsyncWriteThread();
+        startFlushTimer();
 
-        // 2. Handle empty request
         if (request == null || request.getContent() == null || request.getContent().isEmpty()) {
             WriteResponse response = new WriteResponse();
             response.setRequestId(request != null ? request.getRequestId() : null);
@@ -258,32 +226,141 @@ public class RecallEngineClient {
         int itemCount = request.getContent().size();
         InsertMode insertMode = request.getInsertMode();
 
-        // 3. Add to buffer
         writeLock.lock();
         try {
             for (Map<String, Object> data : request.getContent()) {
                 writeData.add(new WriteItem(instanceId, table, data, insertMode));
             }
-            // Signal if batch size reached
             if (writeData.size() >= batchSize) {
-                writeCondition.signal();
+                // Write on the caller's thread. The caller is thereby paced by
+                // the backend, backpressure reaches the producer, and the
+                // buffer cannot outgrow one batch plus one call's worth of rows.
+                flushBufferLocked();
             }
         } finally {
             writeLock.unlock();
         }
 
-        // 4. Return immediate success acknowledgment
         WriteResponse response = new WriteResponse();
         response.setRequestId(request.getRequestId());
         response.setCode("OK");
-        response.setMessage(String.format("Accepted %d items for async write", itemCount));
+        response.setMessage(String.format("Buffered %d items for write", itemCount));
         return response;
     }
 
     /**
-     * Internal synchronous write logic (executed by background thread)
+     * Flush every buffered row synchronously.
      */
-    private WriteResponse doWrite(String instanceId, String table, WriteRequest request) throws RecallEngineException {
+    public void writeFlush() {
+        writeLock.lock();
+        try {
+            flushBufferLocked();
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    /**
+     * Write out the whole buffer, then clear it.
+     *
+     * <p><b>MUST be called while holding {@code writeLock}.</b> Holding the
+     * lock across the HTTP call is intentional: concurrent producers block
+     * until the in-flight batch completes, which is exactly the backpressure
+     * this client is meant to apply.
+     *
+     * <p>Rows are grouped by instance/table/insert-mode (one request per
+     * group) and each group is split into chunks of at most {@code batchSize}
+     * rows. A chunk that fails every retry is logged and dropped; the buffer is
+     * always cleared so a failure cannot make the buffer grow or resend rows.
+     */
+    private void flushBufferLocked() {
+        if (writeData.isEmpty()) {
+            return;
+        }
+        try {
+            // LinkedHashMap: keep the order rows arrived in, so writes to a
+            // given table stay in submission order.
+            Map<String, List<WriteItem>> grouped = new LinkedHashMap<>();
+            for (WriteItem item : writeData) {
+                String key = item.instanceId + "|" + item.table + "|" + item.insertMode.getValue();
+                grouped.computeIfAbsent(key, k -> new ArrayList<>()).add(item);
+            }
+
+            for (List<WriteItem> items : grouped.values()) {
+                String instanceId = items.get(0).instanceId;
+                String table = items.get(0).table;
+                InsertMode insertMode = items.get(0).insertMode;
+
+                for (int start = 0; start < items.size(); start += batchSize) {
+                    int end = Math.min(start + batchSize, items.size());
+                    List<Map<String, Object>> content = new ArrayList<>(end - start);
+                    for (WriteItem item : items.subList(start, end)) {
+                        content.add(item.data);
+                    }
+
+                    WriteRequest request = new WriteRequest();
+                    request.setContent(content);
+                    request.setInsertMode(insertMode);
+
+                    try {
+                        writeWithRetry(instanceId, table, request);
+                        logger.debug("write completed: {} items to {}/{}", content.size(), instanceId, table);
+                    } catch (Exception e) {
+                        // Keep the producer running: report the loss and move on
+                        // to the next chunk rather than failing the whole flush.
+                        logger.error("write failed for {}/{}, dropping {} items: {}",
+                                instanceId, table, content.size(), e.getMessage(), e);
+                    }
+                }
+            }
+        } finally {
+            // Never leave already-processed rows in the buffer, whatever happened.
+            writeData.clear();
+        }
+    }
+
+    /**
+     * Issue one write request, retrying transient failures.
+     *
+     * <p>{@code retryTimes} is the total number of attempts and is floored at
+     * 1, so a client left at the default still sends the request once instead
+     * of silently discarding the batch. Only throttling, server errors and
+     * transport failures are retried; a 4xx will not succeed on a second try.
+     */
+    private void writeWithRetry(String instanceId, String table, WriteRequest request)
+            throws RecallEngineException {
+        int maxAttempts = Math.max(1, retryTimes);
+        for (int attempt = 1; ; attempt++) {
+            try {
+                doWrite(instanceId, table, request);
+                return;
+            } catch (RecallEngineException e) {
+                if (attempt >= maxAttempts || !isRetryable(e.getStatusCode())) {
+                    throw e;
+                }
+                logger.warn("write failed for {}/{}, retrying ({}/{}), err: {}",
+                        instanceId, table, attempt, maxAttempts, e.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Throttling and server-side errors are worth another attempt, as is a
+     * failure that never produced a response (connect/read timeout). Every
+     * other 4xx is a problem with the request itself and will fail again.
+     */
+    private static boolean isRetryable(int statusCode) {
+        return statusCode == RecallEngineException.NO_STATUS_CODE
+                || statusCode == 429
+                || statusCode >= 500;
+    }
+
+    /**
+     * Perform a single write HTTP call. Package-visible rather than private so
+     * tests can substitute failures and observe the batching and retry
+     * behaviour without a server.
+     */
+    WriteResponse doWrite(String instanceId, String table, WriteRequest request) throws RecallEngineException {
         try {
             String json = objectMapper.writeValueAsString(request);
             String url = String.format("%s/api/v1/tables/%s/default/%s/write", endpoint, instanceId, table);
@@ -316,7 +393,7 @@ public class RecallEngineClient {
                     } catch (Exception e) {
                         // Ignore parse error
                     }
-                    throw new RecallEngineException(errorMsg);
+                    throw new RecallEngineException(errorMsg, response.code());
                 }
 
                 return objectMapper.readValue(responseBody, WriteResponse.class);
@@ -324,6 +401,7 @@ public class RecallEngineClient {
         } catch (RecallEngineException e) {
             throw e;
         } catch (Exception e) {
+            // No status code: transport or serialization failure, treated as retryable.
             throw new RecallEngineException("Write request failed", e);
         }
     }
@@ -336,268 +414,53 @@ public class RecallEngineClient {
         return authCache;
     }
 
-    // ==================== Async Implementation Details ====================
-
-    private ExecutorService getWriteExecutor() {
-        ExecutorService executor = writeExecutor;
-        if (executor != null && !executor.isShutdown()) {
-            return executor;
-        }
-        synchronized (this) {
-            executor = writeExecutor;
-            if (executor != null && !executor.isShutdown()) {
-                return executor;
-            }
-            // Refuse to recreate the executor once the client has been closed.
-            // Without this guard, getWriteExecutor() would silently spin up a
-            // new thread pool that nobody owns, leaking threads and accepting
-            // writes that will never be observed by close()/writeFlush().
-            if (!running) {
-                throw new IllegalStateException(
-                        "RecallEngineClient is closed; the async write executor cannot be recreated");
-            }
-            executor = createWriteExecutor();
-            writeExecutor = executor;
-            return executor;
-        }
-    }
-
     /**
-     * Build the async write executor: bounded queue + named daemon threads
-     * + caller-runs rejection policy. Caller-runs propagates backpressure to
-     * the submitting thread (background flush thread or writeFlush() caller)
-     * instead of dropping data on overload.
+     * Start the flush timer thread on first write.
+     *
+     * <p>The thread performs no writing of its own beyond bounding staleness:
+     * it flushes a partial buffer once {@code flushIntervalMs} has elapsed, so
+     * a low-traffic stream does not have to wait for a full batch. Writes it
+     * triggers are synchronous, under the same lock as {@link #write}.
+     *
+     * <p>Double-checked locking keeps the common case lock-free.
      */
-    private ThreadPoolExecutor createWriteExecutor() {
-        ThreadFactory threadFactory = new ThreadFactory() {
-            @Override
-            public Thread newThread(Runnable r) {
-                Thread t = new Thread(r,
-                        "RecallEngineWriter-" + ASYNC_WRITER_THREAD_COUNTER.incrementAndGet());
-                t.setDaemon(true);
-                return t;
-            }
-        };
-        return new ThreadPoolExecutor(
-                writeThreadPoolSize,
-                writeThreadPoolSize,
-                0L, TimeUnit.MILLISECONDS,
-                new LinkedBlockingQueue<Runnable>(writeQueueCapacity),
-                threadFactory,
-                new ThreadPoolExecutor.CallerRunsPolicy());
-    }
-
-    /**
-     * Start the async write background thread.
-     * Uses Double-Checked Locking for thread safety and performance:
-     * - First check without lock (fast path for most calls)
-     * - Only acquire lock when thread needs to be created
-     */
-    private void startAsyncWriteThread() {
-        // Fast path: if thread is already running, return immediately (no lock needed)
-        Thread thread = asyncWriteThread;
+    private void startFlushTimer() {
+        Thread thread = flushTimerThread;
         if (thread != null && thread.isAlive()) {
             return;
         }
 
-        // Slow path: need to create thread, use synchronized
         synchronized (this) {
-            // Double-check after acquiring lock
-            thread = asyncWriteThread;
+            thread = flushTimerThread;
             if (thread != null && thread.isAlive()) {
                 return;
             }
 
-            String threadName = "RecallEngineAsyncWriter";
-            asyncWriteThread = new Thread(() -> {
+            String threadName = "RecallEngineFlushTimer-" + FLUSH_TIMER_THREAD_COUNTER.incrementAndGet();
+            flushTimerThread = new Thread(() -> {
                 while (running) {
-                    boolean shouldBreak = false;
-                    List<WriteItem> drained = null;
-
-                    // Phase 1: lock + await + drain (in-memory only).
                     writeLock.lock();
                     try {
-                        try {
-                            writeCondition.await(flushIntervalMs, TimeUnit.MILLISECONDS);
-                        } catch (InterruptedException e) {
-                            logger.warn("{} interrupted, flushing remaining data before exit", threadName);
-                            Thread.currentThread().interrupt();
-                            shouldBreak = true;
-                        }
-                        drained = drainBufferLocked();
+                        writeCondition.await(flushIntervalMs, TimeUnit.MILLISECONDS);
+                        flushBufferLocked();
+                    } catch (InterruptedException e) {
+                        logger.warn("{} interrupted, flushing remaining data before exit", threadName);
+                        Thread.currentThread().interrupt();
+                        flushBufferLocked();
+                        break;
                     } finally {
                         writeLock.unlock();
-                    }
-
-                    // Phase 2: submit OUTSIDE the lock so CallerRunsPolicy never
-                    // forces an HTTP write while writeLock is held.
-                    if (drained != null) {
-                        try {
-                            submitBatch(drained);
-                        } catch (Exception ex) {
-                            logger.error("Failed to submit batch", ex);
-                        }
-                    }
-
-                    if (shouldBreak) {
-                        break;
-                    }
-                }
-
-                // Final drain after the loop exits: same lock-then-submit pattern.
-                List<WriteItem> finalDrained;
-                writeLock.lock();
-                try {
-                    finalDrained = drainBufferLocked();
-                } finally {
-                    writeLock.unlock();
-                }
-                if (finalDrained != null) {
-                    try {
-                        submitBatch(finalDrained);
-                    } catch (Exception ex) {
-                        logger.error("Failed to submit final batch", ex);
                     }
                 }
                 logger.info("{} has stopped.", threadName);
             }, threadName);
-            asyncWriteThread.setDaemon(true);
-            asyncWriteThread.start();
+            flushTimerThread.setDaemon(true);
+            flushTimerThread.start();
         }
     }
 
     /**
-     * Force flush remaining data and wait for the HTTP batch to complete.
-     * <p>
-     * The HTTP request is submitted while holding the buffer lock, but the
-     * caller waits for completion <em>outside</em> the lock so that concurrent
-     * producers ({@link #write}) and the background flush thread are not
-     * blocked by network I/O. The wait is bounded by {@code flushTimeoutMs}
-     * configured via {@link #withFlushTimeoutMs(long)}.
-     */
-    public void writeFlush() {
-        // Phase 1: drain the buffer while holding the lock (in-memory only).
-        List<WriteItem> drained;
-        writeLock.lock();
-        try {
-            drained = drainBufferLocked();
-        } finally {
-            writeLock.unlock();
-        }
-
-        if (drained == null) {
-            return;
-        }
-
-        int pendingCount = drained.size();
-        logger.info("Write flush: {} items pending", pendingCount);
-
-        // Phase 2: submit OUTSIDE the lock. CallerRunsPolicy may execute the
-        // task synchronously when the executor queue is full; doing it without
-        // holding writeLock keeps producers and the background flusher unblocked.
-        Future<?> future = submitBatch(drained);
-
-        try {
-            future.get(flushTimeoutMs, TimeUnit.MILLISECONDS);
-        } catch (TimeoutException e) {
-            logger.error("Write flush timed out after {} ms with {} items in flight; cancelling",
-                    flushTimeoutMs, pendingCount);
-            future.cancel(true);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            future.cancel(true);
-            logger.warn("Write flush interrupted while waiting for completion");
-        } catch (Exception e) {
-            logger.error("Error waiting for write completion: {}", e.getMessage(), e);
-        }
-    }
-
-    /**
-     * Drain the in-memory write buffer into a temporary list.
-     * <p>
-     * <b>MUST be called while holding {@code writeLock}.</b> The method only
-     * touches the in-memory buffer (no I/O), so the lock is released quickly.
-     *
-     * @return the drained items, or {@code null} when the buffer was empty
-     */
-    private List<WriteItem> drainBufferLocked() {
-        if (writeData.isEmpty()) {
-            return null;
-        }
-        List<WriteItem> tempList = new ArrayList<>(writeData);
-        writeData.clear();
-        return tempList;
-    }
-
-    /**
-     * Submit a drained batch to the write executor.
-     * <p>
-     * <b>MUST be called WITHOUT holding {@code writeLock}.</b> When the executor
-     * task queue is full, {@link java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy}
-     * runs the task on the calling thread; if that thread were holding
-     * {@code writeLock}, the lock would be retained throughout the HTTP write
-     * (and its retries), blocking every {@link #write} producer and the
-     * background flush thread.
-     *
-     * @param tempList already-drained items, must be non-empty
-     * @return Future for tracking completion of the submitted batch
-     */
-    private Future<?> submitBatch(final List<WriteItem> tempList) {
-        return getWriteExecutor().submit(() -> {
-            // Group by Instance/Table/InsertMode to minimize requests
-            Map<String, List<WriteItem>> grouped = new HashMap<>();
-            for (WriteItem item : tempList) {
-                String key = item.instanceId + "|" + item.table + "|" + item.insertMode.getValue();
-                grouped.computeIfAbsent(key, k -> new ArrayList<>()).add(item);
-            }
-
-            // Write each group
-            for (List<WriteItem> items : grouped.values()) {
-                if (items.isEmpty()) continue;
-
-                String instId = items.get(0).instanceId;
-                String tbl = items.get(0).table;
-                InsertMode mode = items.get(0).insertMode;
-
-                try {
-                    WriteRequest request = new WriteRequest();
-                    List<Map<String, Object>> content = new ArrayList<>(items.size());
-                    for (WriteItem item : items) {
-                        content.add(item.data);
-                    }
-                    request.setContent(content);
-                    request.setInsertMode(mode);
-
-                    // Execute actual HTTP call with retry
-                    if (retryTimes > 0) {
-                        RecallEngineException lastException = null;
-                        for (int i = 0; i < retryTimes; i++) {
-                            try {
-                                doWrite(instId, tbl, request);
-                                lastException = null;
-                                break;
-                            } catch (RecallEngineException e) {
-                                lastException = e;
-                                logger.warn("Async write failed, retrying ({}/{}), err: {}", i + 1, retryTimes, e.getMessage());
-                            }
-                        }
-                        if (lastException != null) {
-                            throw lastException;
-                        }
-                    } else {
-                        doWrite(instId, tbl, request);
-                    }
-
-                    logger.debug("Async write completed: {} items to {}/{}", items.size(), instId, tbl);
-                } catch (Exception e) {
-                    logger.error("Async write failed for {}/{}: {}", instId, tbl, e.getMessage(), e);
-                }
-            }
-        });
-    }
-
-    /**
-     * Close client resources
+     * Flush whatever is buffered and stop accepting writes.
      */
     public void close() {
         this.running = false;
@@ -609,36 +472,20 @@ public class RecallEngineClient {
             writeLock.unlock();
         }
 
-        // Wait for async write thread to stop. No timeout here: the worker
-        // exits its loop as soon as it observes running=false, plus an upper
-        // bound of flushIntervalMs in await(); a hard 1s ceiling used to cut
-        // the worker off mid-flush and silently drop buffered records.
-        if (asyncWriteThread != null && asyncWriteThread.isAlive()) {
+        // The timer thread observes running=false within at most
+        // flushIntervalMs and flushes on its way out; no hard timeout here,
+        // because cutting it off mid-flush would drop buffered rows.
+        Thread thread = flushTimerThread;
+        if (thread != null && thread.isAlive()) {
             try {
-                asyncWriteThread.join();
+                thread.join();
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }
         }
 
-        // Flush remaining data
+        // Anything the timer thread did not get to.
         writeFlush();
-
-        // Shutdown executor. Allow up to 15s for already-submitted HTTP
-        // batches (including their retries) to complete before forcing
-        // shutdownNow(); the previous 5s ceiling routinely interrupted
-        // in-flight requests on slow backends and lost data.
-        if (writeExecutor != null && !writeExecutor.isShutdown()) {
-            writeExecutor.shutdown();
-            try {
-                if (!writeExecutor.awaitTermination(15, TimeUnit.SECONDS)) {
-                    writeExecutor.shutdownNow();
-                }
-            } catch (InterruptedException e) {
-                writeExecutor.shutdownNow();
-                Thread.currentThread().interrupt();
-            }
-        }
     }
 
     // ==================== Inner Class ====================

--- a/src/main/java/com/aliyun/openservices/pairec/recallengine/RecallEngineException.java
+++ b/src/main/java/com/aliyun/openservices/pairec/recallengine/RecallEngineException.java
@@ -4,16 +4,40 @@ package com.aliyun.openservices.pairec.recallengine;
  * RecallEngine exception for recall and write operations
  */
 public class RecallEngineException extends Exception {
-    
+
+    /**
+     * HTTP status code returned by the service, or {@link #NO_STATUS_CODE} when
+     * the failure happened before a response was received (connect/read
+     * timeout, DNS failure, serialization error, ...).
+     */
+    public static final int NO_STATUS_CODE = 0;
+
+    private final int statusCode;
+
     public RecallEngineException(String message) {
-        super(message);
+        this(message, NO_STATUS_CODE);
     }
-    
+
+    public RecallEngineException(String message, int statusCode) {
+        super(message);
+        this.statusCode = statusCode;
+    }
+
     public RecallEngineException(String message, Throwable cause) {
         super(message, cause);
+        this.statusCode = NO_STATUS_CODE;
     }
-    
+
     public RecallEngineException(Throwable cause) {
         super(cause);
+        this.statusCode = NO_STATUS_CODE;
+    }
+
+    /**
+     * @return the HTTP status code, or {@link #NO_STATUS_CODE} if the request
+     *         never produced a response
+     */
+    public int getStatusCode() {
+        return statusCode;
     }
 }

--- a/src/main/java/com/aliyun/openservices/pairec/recallengine/flink/factory/RecallEngineTableFactory.java
+++ b/src/main/java/com/aliyun/openservices/pairec/recallengine/flink/factory/RecallEngineTableFactory.java
@@ -57,6 +57,16 @@ public class RecallEngineTableFactory implements DynamicTableSinkFactory {
             .defaultValue("insert")
             .withDescription("Write mode: 'insert' (default) or 'upsert'");
 
+    public static final ConfigOption<Integer> BATCH_SIZE = ConfigOptions.key("batch_size")
+            .intType()
+            .defaultValue(200)
+            .withDescription("Rows per write request; the sink flushes as soon as this many rows are buffered");
+
+    public static final ConfigOption<Long> FLUSH_INTERVAL_MS = ConfigOptions.key("flush_interval_ms")
+            .longType()
+            .defaultValue(50L)
+            .withDescription("Flush a partial batch after this many milliseconds");
+
     @Override
     public DynamicTableSink createDynamicTableSink(Context context) {
         final FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
@@ -76,13 +86,16 @@ public class RecallEngineTableFactory implements DynamicTableSinkFactory {
         }
 
         InsertMode insertMode = InsertMode.fromValue(options.get(INSERT_MODE));
+        final int batchSize = options.get(BATCH_SIZE);
+        final long flushIntervalMs = options.get(FLUSH_INTERVAL_MS);
 
         final DataType producedDataType =
                 context.getCatalogTable().getResolvedSchema().toPhysicalRowDataType();
 
         return new RecallEngineDynamicTableSink(
                 endpoint, instanceId, table, username, password,
-                retryTimes, authorization, insertMode, producedDataType);
+                retryTimes, authorization, insertMode, batchSize, flushIntervalMs,
+                producedDataType);
     }
     
     @Override
@@ -107,6 +120,8 @@ public class RecallEngineTableFactory implements DynamicTableSinkFactory {
         options.add(RETRY_TIMES);
         options.add(AUTHORIZATION);
         options.add(INSERT_MODE);
+        options.add(BATCH_SIZE);
+        options.add(FLUSH_INTERVAL_MS);
         return options;
     }
 }

--- a/src/main/java/com/aliyun/openservices/pairec/recallengine/flink/factory/RecallEngineTableFactory.java
+++ b/src/main/java/com/aliyun/openservices/pairec/recallengine/flink/factory/RecallEngineTableFactory.java
@@ -5,6 +5,7 @@ import com.aliyun.openservices.pairec.recallengine.flink.sink.RecallEngineDynami
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.factories.DynamicTableSinkFactory;
 import org.apache.flink.table.factories.FactoryUtil;
@@ -86,8 +87,19 @@ public class RecallEngineTableFactory implements DynamicTableSinkFactory {
         }
 
         InsertMode insertMode = InsertMode.fromValue(options.get(INSERT_MODE));
+        // Validate here rather than letting the client reject these when the
+        // first record arrives: a bad value should fail job submission, not a
+        // running job.
         final int batchSize = options.get(BATCH_SIZE);
+        if (batchSize <= 0) {
+            throw new ValidationException(
+                    String.format("'%s' must be positive, got %d", BATCH_SIZE.key(), batchSize));
+        }
         final long flushIntervalMs = options.get(FLUSH_INTERVAL_MS);
+        if (flushIntervalMs <= 0) {
+            throw new ValidationException(
+                    String.format("'%s' must be positive, got %d", FLUSH_INTERVAL_MS.key(), flushIntervalMs));
+        }
 
         final DataType producedDataType =
                 context.getCatalogTable().getResolvedSchema().toPhysicalRowDataType();

--- a/src/main/java/com/aliyun/openservices/pairec/recallengine/flink/sink/RecallEngineDynamicTableSink.java
+++ b/src/main/java/com/aliyun/openservices/pairec/recallengine/flink/sink/RecallEngineDynamicTableSink.java
@@ -18,6 +18,8 @@ public class RecallEngineDynamicTableSink implements DynamicTableSink {
     private final int retryTimes;
     private final String authorization;
     private final InsertMode insertMode;
+    private final int batchSize;
+    private final long flushIntervalMs;
     private final DataType dataType;
 
     public RecallEngineDynamicTableSink(
@@ -29,6 +31,8 @@ public class RecallEngineDynamicTableSink implements DynamicTableSink {
             int retryTimes,
             String authorization,
             InsertMode insertMode,
+            int batchSize,
+            long flushIntervalMs,
             DataType dataType) {
         this.endpoint = endpoint;
         this.instanceId = instanceId;
@@ -38,6 +42,8 @@ public class RecallEngineDynamicTableSink implements DynamicTableSink {
         this.retryTimes = retryTimes;
         this.authorization = authorization;
         this.insertMode = insertMode;
+        this.batchSize = batchSize;
+        this.flushIntervalMs = flushIntervalMs;
         this.dataType = dataType;
     }
     
@@ -53,7 +59,7 @@ public class RecallEngineDynamicTableSink implements DynamicTableSink {
     public SinkRuntimeProvider getSinkRuntimeProvider(Context context) {
         RecallEngineSinkFunction sinkFunction = new RecallEngineSinkFunction(
                 endpoint, instanceId, table, username, password,
-                retryTimes, authorization, insertMode, dataType);
+                retryTimes, authorization, insertMode, batchSize, flushIntervalMs, dataType);
         return SinkFunctionProvider.of(sinkFunction);
     }
 
@@ -61,7 +67,7 @@ public class RecallEngineDynamicTableSink implements DynamicTableSink {
     public DynamicTableSink copy() {
         return new RecallEngineDynamicTableSink(
                 endpoint, instanceId, table, username, password,
-                retryTimes, authorization, insertMode, dataType);
+                retryTimes, authorization, insertMode, batchSize, flushIntervalMs, dataType);
     }
     
     @Override

--- a/src/main/java/com/aliyun/openservices/pairec/recallengine/flink/sink/RecallEngineSinkFunction.java
+++ b/src/main/java/com/aliyun/openservices/pairec/recallengine/flink/sink/RecallEngineSinkFunction.java
@@ -41,10 +41,12 @@ public class RecallEngineSinkFunction extends RichSinkFunction<RowData> {
     private final int retryTimes;
     private final String authorization;
     private final InsertMode insertMode;
+    private final int batchSize;
+    private final long flushIntervalMs;
     private final List<RowType.RowField> fields;
-    
+
     private transient RecallEngineClient client;
-    
+
     public RecallEngineSinkFunction(
             String endpoint,
             String instanceId,
@@ -54,6 +56,8 @@ public class RecallEngineSinkFunction extends RichSinkFunction<RowData> {
             int retryTimes,
             String authorization,
             InsertMode insertMode,
+            int batchSize,
+            long flushIntervalMs,
             DataType dataType) {
         this.endpoint = endpoint;
         this.instanceId = instanceId;
@@ -63,16 +67,20 @@ public class RecallEngineSinkFunction extends RichSinkFunction<RowData> {
         this.retryTimes = retryTimes;
         this.authorization = authorization;
         this.insertMode = insertMode;
-        
+        this.batchSize = batchSize;
+        this.flushIntervalMs = flushIntervalMs;
+
         RowType rowType = (RowType) dataType.getLogicalType();
         this.fields = rowType.getFields();
     }
-    
+
     private void initializeClient() {
         if (this.client == null) {
             this.client = new RecallEngineClient(endpoint, username, password)
-                    .withRetryTimes(retryTimes);
-            
+                    .withRetryTimes(retryTimes)
+                    .withBatchSize(batchSize)
+                    .withFlushInterval(flushIntervalMs);
+
             if (authorization != null && !authorization.isEmpty()) {
                 this.client.withRequestHeader("Authorization", authorization);
             }
@@ -106,6 +114,11 @@ public class RecallEngineSinkFunction extends RichSinkFunction<RowData> {
             request.setInsertMode(insertMode);
 
             try {
+                // Blocks whenever the buffer has filled up and the batch is
+                // being sent, so a slow backend backpressures this task instead
+                // of piling rows up in memory. HTTP failures are retried and
+                // then logged inside the client, so what reaches this catch is
+                // an unexpected client-state error, not a backend hiccup.
                 client.write(instanceId, table, request);
             } catch (Exception e) {
                 LOG.error("Failed to write data to RecallEngine. instanceId: {}, table: {}, data: {}, error: {}",
@@ -154,7 +167,7 @@ public class RecallEngineSinkFunction extends RichSinkFunction<RowData> {
     @Override
     public void close() throws Exception {
         if (client != null) {
-            client.writeFlush();
+            // close() flushes whatever is still buffered before returning.
             client.close();
         }
         super.close();

--- a/src/test/java/com/aliyun/openservices/pairec/recallengine/RecallEngineClientTest.java
+++ b/src/test/java/com/aliyun/openservices/pairec/recallengine/RecallEngineClientTest.java
@@ -3,15 +3,11 @@ package com.aliyun.openservices.pairec.recallengine;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.net.ServerSocket;
-import java.net.Socket;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -87,168 +83,17 @@ public class RecallEngineClientTest {
     }
 
     /**
-     * Verifies the fix for the "writeFlush holds the buffer lock while waiting
-     * on HTTP" issue: concurrent producers must not be blocked by an in-flight
-     * flush. Uses a localhost ServerSocket as a TCP blackhole — connections
-     * are accepted but never read/written — so the OkHttp client hangs until
-     * its read/write timeout fires. During that window the test issues a
-     * second write() and asserts it returns promptly.
-     */
-    @Test(timeout = 15000)
-    public void testWriteFlushDoesNotBlockProducers() throws Exception {
-        try (ServerSocket blackhole = new ServerSocket(0)) {
-            // Accept connections but never respond; keep the sockets alive so
-            // OkHttp blocks on read/write timeout (~500ms) instead of failing
-            // fast on connection-refused.
-            final java.util.List<Socket> accepted = Collections.synchronizedList(new java.util.ArrayList<>());
-            Thread acceptor = new Thread(() -> {
-                while (!Thread.currentThread().isInterrupted()) {
-                    try {
-                        accepted.add(blackhole.accept());
-                    } catch (Exception ignored) {
-                        return;
-                    }
-                }
-            }, "test-blackhole-acceptor");
-            acceptor.setDaemon(true);
-            acceptor.start();
-
-            String endpoint = "http://127.0.0.1:" + blackhole.getLocalPort();
-            RecallEngineClient cli = new RecallEngineClient(endpoint, "u", "p")
-                    .withBatchSize(10000)         // never auto-trigger by size
-                    .withFlushInterval(60_000)    // never auto-trigger by time
-                    .withFlushTimeoutMs(2000);    // bound the flush wait
-
-            try {
-                // Seed one item so writeFlush has data to drain
-                WriteRequest seed = new WriteRequest();
-                Map<String, Object> row = new HashMap<>();
-                row.put("id", "1");
-                seed.setContent(Collections.singletonList(row));
-                cli.write("inst", "tbl", seed);
-
-                // Run flush in background. With the fix, it submits the HTTP
-                // task while holding writeLock, then releases the lock and
-                // waits on the future outside the lock.
-                Thread flusher = new Thread(cli::writeFlush, "test-flusher");
-                flusher.start();
-
-                // Give flusher time to enter future.get() (lock released by now)
-                Thread.sleep(100);
-
-                // Concurrent producer must not be blocked by the in-flight HTTP.
-                // Pre-fix: this call would block ~500ms (until OkHttp timeout).
-                // Post-fix: only contends for the buffer lock, which is free.
-                long t0 = System.nanoTime();
-                WriteRequest req2 = new WriteRequest();
-                Map<String, Object> row2 = new HashMap<>();
-                row2.put("id", "2");
-                req2.setContent(Collections.singletonList(row2));
-                cli.write("inst", "tbl", req2);
-                long writeElapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - t0);
-
-                assertTrue("write() blocked while writeFlush() was awaiting HTTP: "
-                                + writeElapsedMs + "ms",
-                        writeElapsedMs < 200);
-
-                // Flush must terminate within flushTimeoutMs + slack
-                flusher.join(5000);
-                assertFalse("writeFlush() did not return within timeout window",
-                        flusher.isAlive());
-            } finally {
-                cli.close();
-                acceptor.interrupt();
-                for (Socket s : accepted) {
-                    try { s.close(); } catch (Exception ignored) {}
-                }
-            }
-        }
-    }
-
-    /**
-     * Verifies the async write executor is built with the hardened settings:
-     * named daemon threads (so jstack is readable and JVM exit is not blocked)
-     * and a bounded task queue with caller-runs rejection (so a slow backend
-     * applies backpressure to producers instead of growing memory unbounded).
-     */
-    @Test(timeout = 5000)
-    public void testWriteExecutorIsHardened() throws Exception {
-        // Stand up a localhost blackhole so HTTP submissions stay in flight
-        // long enough for the executor's worker threads to be observable.
-        try (ServerSocket blackhole = new ServerSocket(0)) {
-            final java.util.List<Socket> accepted = Collections.synchronizedList(new java.util.ArrayList<>());
-            Thread acceptor = new Thread(() -> {
-                while (!Thread.currentThread().isInterrupted()) {
-                    try {
-                        accepted.add(blackhole.accept());
-                    } catch (Exception ignored) {
-                        return;
-                    }
-                }
-            }, "test-blackhole-acceptor");
-            acceptor.setDaemon(true);
-            acceptor.start();
-
-            String endpoint = "http://127.0.0.1:" + blackhole.getLocalPort();
-            RecallEngineClient cli = new RecallEngineClient(endpoint, "u", "p")
-                    .withWriteThreadPoolSize(2)
-                    .withBatchSize(1)              // each write triggers flush
-                    .withFlushInterval(60_000);
-
-            try {
-                // Submit a few writes to wake the worker threads
-                for (int i = 0; i < 4; i++) {
-                    WriteRequest req = new WriteRequest();
-                    Map<String, Object> row = new HashMap<>();
-                    row.put("id", String.valueOf(i));
-                    req.setContent(Collections.singletonList(row));
-                    cli.write("inst", "tbl", req);
-                }
-
-                // Allow background flush thread + executor workers to start.
-                Thread.sleep(200);
-
-                // Inspect live threads for the configured naming + daemon flags.
-                Thread[] all = new Thread[Thread.activeCount() * 2];
-                int n = Thread.enumerate(all);
-                int writerCount = 0;
-                for (int i = 0; i < n; i++) {
-                    Thread t = all[i];
-                    if (t == null) continue;
-                    if (t.getName().startsWith("RecallEngineWriter-")) {
-                        writerCount++;
-                        assertTrue("worker thread '" + t.getName() + "' must be daemon",
-                                t.isDaemon());
-                    }
-                }
-                assertTrue("expected at least one RecallEngineWriter-* thread, found " + writerCount,
-                        writerCount >= 1);
-            } finally {
-                cli.close();
-                acceptor.interrupt();
-                for (Socket s : accepted) {
-                    try { s.close(); } catch (Exception ignored) {}
-                }
-            }
-        }
-    }
-
-    /**
      * Verifies that calling write() after close() fails fast instead of
-     * silently dropping data. Pre-fix: write() would add to the (drained)
-     * buffer and getWriteExecutor() would spin up a new orphan thread pool
-     * that no one owns. Post-fix: both call sites refuse with
-     * IllegalStateException.
+     * silently dropping data: close() flushes and drains the buffer, so a row
+     * added afterwards would have nothing left to write it out.
      */
     @Test(timeout = 5000)
     public void testWriteAfterCloseThrows() {
-        // Endpoint is irrelevant — we never reach the network. Use a port that
-        // is unlikely to be open; even a connection failure is fine because
-        // close() is what we exercise here.
+        // Endpoint is irrelevant — we never reach the network, because the
+        // buffer never fills and close() flushes an empty buffer.
         RecallEngineClient cli = new RecallEngineClient("http://127.0.0.1:1", "u", "p")
                 .withBatchSize(10000)
-                .withFlushInterval(60_000)
-                .withFlushTimeoutMs(500);
+                .withFlushInterval(60_000);
 
         cli.close();
 

--- a/src/test/java/com/aliyun/openservices/pairec/recallengine/RecallEngineClientTest.java
+++ b/src/test/java/com/aliyun/openservices/pairec/recallengine/RecallEngineClientTest.java
@@ -80,6 +80,11 @@ public class RecallEngineClientTest {
         WriteResponse resp = client.write(instanceId, "u2i_table", request);
         assertEquals("write-req-123", resp.getRequestId());
         assertEquals("OK", resp.getCode());
+
+        // One row does not fill a batch, so the request is still buffered here.
+        // Flush so the row actually reaches the service instead of being
+        // dropped when the test JVM exits.
+        client.writeFlush();
     }
 
     /**

--- a/src/test/java/com/aliyun/openservices/pairec/recallengine/RecallEngineClientWriteTest.java
+++ b/src/test/java/com/aliyun/openservices/pairec/recallengine/RecallEngineClientWriteTest.java
@@ -1,0 +1,301 @@
+package com.aliyun.openservices.pairec.recallengine;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Covers the synchronous buffered write path: batching, slicing, grouping,
+ * retry classification and buffer hygiene. {@link RecallEngineClient#doWrite}
+ * is stubbed out so no server is needed.
+ */
+public class RecallEngineClientWriteTest {
+
+    /** One observed call to doWrite. */
+    private static class Call {
+        final String instanceId;
+        final String table;
+        final int rows;
+        final InsertMode insertMode;
+        final String threadName;
+
+        Call(String instanceId, String table, int rows, InsertMode insertMode, String threadName) {
+            this.instanceId = instanceId;
+            this.table = table;
+            this.rows = rows;
+            this.insertMode = insertMode;
+            this.threadName = threadName;
+        }
+    }
+
+    /**
+     * Client that records every write attempt instead of sending it, and can be
+     * told to fail the first N attempts with a given HTTP status.
+     */
+    private static class RecordingClient extends RecallEngineClient {
+        final List<Call> calls = Collections.synchronizedList(new ArrayList<Call>());
+        volatile int failuresRemaining = 0;
+        volatile int failureStatusCode = 503;
+
+        RecordingClient() {
+            // Never dialled: doWrite is overridden.
+            super("http://127.0.0.1:1", "u", "p");
+        }
+
+        @Override
+        WriteResponse doWrite(String instanceId, String table, WriteRequest request)
+                throws RecallEngineException {
+            calls.add(new Call(instanceId, table, request.getContent().size(),
+                    request.getInsertMode(), Thread.currentThread().getName()));
+            if (failuresRemaining > 0) {
+                failuresRemaining--;
+                throw new RecallEngineException("injected failure", failureStatusCode);
+            }
+            WriteResponse response = new WriteResponse();
+            response.setCode("OK");
+            return response;
+        }
+    }
+
+    private static WriteRequest requestOf(int rows) {
+        return requestOf(rows, InsertMode.INSERT);
+    }
+
+    private static WriteRequest requestOf(int rows, InsertMode insertMode) {
+        List<Map<String, Object>> content = new ArrayList<>(rows);
+        for (int i = 0; i < rows; i++) {
+            Map<String, Object> row = new HashMap<>();
+            row.put("id", String.valueOf(i));
+            content.add(row);
+        }
+        WriteRequest request = new WriteRequest();
+        request.setContent(content);
+        request.setInsertMode(insertMode);
+        return request;
+    }
+
+    /**
+     * Rows sit in the buffer until a full batch has accumulated, and the batch
+     * is then written on the caller's own thread — that inline write is what
+     * paces the producer.
+     */
+    @Test(timeout = 10000)
+    public void testFlushesOnCallerThreadWhenBatchFull() {
+        RecordingClient client = new RecordingClient();
+        client.withBatchSize(3).withFlushInterval(60_000);
+        try {
+            client.write("inst", "tbl", requestOf(2));
+            assertEquals("partial batch must not be written yet", 0, client.calls.size());
+
+            client.write("inst", "tbl", requestOf(1));
+            assertEquals("full batch must be written before write() returns",
+                    1, client.calls.size());
+            assertEquals(3, client.calls.get(0).rows);
+            assertEquals("write must happen on the calling thread, not a pool thread",
+                    Thread.currentThread().getName(), client.calls.get(0).threadName);
+        } finally {
+            client.close();
+        }
+    }
+
+    /**
+     * A burst larger than one batch must be split, not coalesced into a single
+     * oversized request.
+     */
+    @Test(timeout = 10000)
+    public void testBatchIsSlicedToBatchSize() {
+        RecordingClient client = new RecordingClient();
+        client.withBatchSize(200).withFlushInterval(60_000);
+        try {
+            client.write("inst", "tbl", requestOf(500));
+
+            assertEquals(3, client.calls.size());
+            assertEquals(200, client.calls.get(0).rows);
+            assertEquals(200, client.calls.get(1).rows);
+            assertEquals(100, client.calls.get(2).rows);
+        } finally {
+            client.close();
+        }
+    }
+
+    /** Rows for different tables or insert modes cannot share a request. */
+    @Test(timeout = 10000)
+    public void testGroupsByTableAndInsertMode() {
+        RecordingClient client = new RecordingClient();
+        client.withBatchSize(4).withFlushInterval(60_000);
+        try {
+            client.write("inst", "tbl_a", requestOf(1, InsertMode.INSERT));
+            client.write("inst", "tbl_b", requestOf(1, InsertMode.INSERT));
+            client.write("inst", "tbl_a", requestOf(1, InsertMode.UPSERT));
+            client.write("inst", "tbl_a", requestOf(1, InsertMode.INSERT));
+
+            assertEquals("one request per instance/table/mode group", 3, client.calls.size());
+            for (Call call : client.calls) {
+                if ("tbl_b".equals(call.table)) {
+                    assertEquals(1, call.rows);
+                } else if (call.insertMode == InsertMode.UPSERT) {
+                    assertEquals(1, call.rows);
+                } else {
+                    assertEquals("both INSERT rows for tbl_a share one request", 2, call.rows);
+                }
+            }
+        } finally {
+            client.close();
+        }
+    }
+
+    /** A 503 is transient: keep trying up to retryTimes attempts. */
+    @Test(timeout = 10000)
+    public void testRetriesServerErrorUntilSuccess() {
+        RecordingClient client = new RecordingClient();
+        client.withBatchSize(1).withFlushInterval(60_000).withRetryTimes(3);
+        client.failureStatusCode = 503;
+        client.failuresRemaining = 2;
+        try {
+            client.write("inst", "tbl", requestOf(1));
+
+            assertEquals("two failures then one success", 3, client.calls.size());
+        } finally {
+            client.close();
+        }
+    }
+
+    /** 429 means slow down, which a retry can still satisfy. */
+    @Test(timeout = 10000)
+    public void testRetriesThrottling() {
+        RecordingClient client = new RecordingClient();
+        client.withBatchSize(1).withFlushInterval(60_000).withRetryTimes(2);
+        client.failureStatusCode = 429;
+        client.failuresRemaining = 1;
+        try {
+            client.write("inst", "tbl", requestOf(1));
+
+            assertEquals(2, client.calls.size());
+        } finally {
+            client.close();
+        }
+    }
+
+    /** A malformed request will be just as malformed on the second attempt. */
+    @Test(timeout = 10000)
+    public void testDoesNotRetryClientError() {
+        RecordingClient client = new RecordingClient();
+        client.withBatchSize(1).withFlushInterval(60_000).withRetryTimes(5);
+        client.failureStatusCode = 400;
+        client.failuresRemaining = 5;
+        try {
+            client.write("inst", "tbl", requestOf(1));
+
+            assertEquals("4xx must not be retried", 1, client.calls.size());
+        } finally {
+            client.close();
+        }
+    }
+
+    /**
+     * A failure with no response at all (connect/read timeout) is transient and
+     * must be retried.
+     */
+    @Test(timeout = 10000)
+    public void testRetriesTransportFailure() {
+        RecordingClient client = new RecordingClient();
+        client.withBatchSize(1).withFlushInterval(60_000).withRetryTimes(3);
+        client.failureStatusCode = RecallEngineException.NO_STATUS_CODE;
+        client.failuresRemaining = 2;
+        try {
+            client.write("inst", "tbl", requestOf(1));
+
+            assertEquals(3, client.calls.size());
+        } finally {
+            client.close();
+        }
+    }
+
+    /**
+     * retryTimes is a total attempt count and is floored at 1, so a client left
+     * at the default still sends the batch instead of dropping it.
+     */
+    @Test(timeout = 10000)
+    public void testSendsOnceWhenRetryTimesIsZero() {
+        RecordingClient client = new RecordingClient();
+        client.withBatchSize(1).withFlushInterval(60_000).withRetryTimes(0);
+        try {
+            client.write("inst", "tbl", requestOf(1));
+
+            assertEquals(1, client.calls.size());
+        } finally {
+            client.close();
+        }
+    }
+
+    /**
+     * A batch that exhausts its retries is dropped, not left in the buffer:
+     * otherwise the buffer would grow without bound and the next flush would
+     * resend rows the backend already rejected.
+     */
+    @Test(timeout = 10000)
+    public void testFailedBatchIsNotLeftInBuffer() {
+        RecordingClient client = new RecordingClient();
+        client.withBatchSize(2).withFlushInterval(60_000).withRetryTimes(1);
+        client.failureStatusCode = 400;
+        client.failuresRemaining = Integer.MAX_VALUE;
+        try {
+            client.write("inst", "tbl", requestOf(2));
+            assertEquals(1, client.calls.size());
+
+            // Buffer must be empty now, so an explicit flush has nothing to send.
+            client.writeFlush();
+            assertEquals("failed rows must not be retained or resent",
+                    1, client.calls.size());
+        } finally {
+            client.close();
+        }
+    }
+
+    /**
+     * A stream that never fills a batch must still land: the flush timer writes
+     * out a partial buffer once the interval has elapsed.
+     */
+    @Test(timeout = 10000)
+    public void testFlushTimerWritesPartialBatch() throws Exception {
+        RecordingClient client = new RecordingClient();
+        client.withBatchSize(10_000).withFlushInterval(30);
+        try {
+            client.write("inst", "tbl", requestOf(1));
+
+            long deadline = System.currentTimeMillis() + 5000;
+            while (client.calls.isEmpty() && System.currentTimeMillis() < deadline) {
+                Thread.sleep(10);
+            }
+
+            assertEquals("partial batch must be flushed by the timer", 1, client.calls.size());
+            assertEquals(1, client.calls.get(0).rows);
+            assertTrue("timer thread should own the flush, not the producer",
+                    client.calls.get(0).threadName.startsWith("RecallEngineFlushTimer-"));
+        } finally {
+            client.close();
+        }
+    }
+
+    /** close() must not leave buffered rows behind. */
+    @Test(timeout = 10000)
+    public void testCloseFlushesRemainingRows() {
+        RecordingClient client = new RecordingClient();
+        client.withBatchSize(10_000).withFlushInterval(60_000);
+
+        client.write("inst", "tbl", requestOf(5));
+        assertEquals(0, client.calls.size());
+
+        client.close();
+
+        assertEquals("close() must flush the buffer", 1, client.calls.size());
+        assertEquals(5, client.calls.get(0).rows);
+    }
+}


### PR DESCRIPTION
## 背景

写入链路原来是「缓冲区 → 后台线程 → 线程池」的异步三级结构，`write()` 立刻返回一个后端从未见过的 ACK。由此带来三个问题：

- **没有反压。** 缓冲区是无界 `ArrayList`，唯一有界的队列是 executor 的，而它的 `CallerRunsPolicy` 顶回去的是内部 flush 线程、不是生产者。后端一慢，缓冲区一直涨到 TaskManager OOM。
- **单请求没有上限。** `batchSize` 只决定何时唤醒 flush 线程；flush 会把整个缓冲区塞进一个请求，突发流量被拼成一个超大 body。
- **重试帮不上忙。** 所有失败都重试，包括重试也不可能成功的 4xx；重试耗尽后异常被吞在没有调用方能观测到的地方。

参考 featurestore SDK 的同类改造：aliyun/aliyun-pai-featurestore-java-sdk@6af66e0

## 改法

攒够 `batchSize` 行就**在调用线程上**写出去。生产者因此被真实写入吞吐限速，这就是反压，缓冲区也不会超过一批的量。单请求按 `batchSize` 切片封顶。只重试限流、服务端错误和「压根没拿到响应」的传输失败；`retryTimes` 下限取 1，让保持默认配置的 client 仍然会把这批数据发出去。

定时器线程保留，但只用来给「永远攒不满一批」的低流量场景兜时效底，它触发的写入同样是同步的、同样持锁，所以不影响反压。executor、Future、以及为它们服务的 flush 超时全部删除，连同当初为了防它们丢数据而加的那些 `close()` 超时。

`RecallEngineClient` 净减 153 行。

写入失败的语义是**记日志后丢弃、作业继续**（对齐参考 commit 里 dao 的行为）。所以 `RecallEngineSinkFunction` 里那个 `throw` 现在只兜「client 状态用错」和 `Error`，后端抖动不会打断作业。**建议对 `write failed for .../..., dropping N items` 这条 error 日志配告警**，否则静默丢数据没人会发现。

## 顺带

- `RecallEngineException` 增加 `getStatusCode()`，重试分类需要
- Flink DDL 新增 `batch_size`（默认 200）和 `flush_interval_ms`（默认 50），非法值在作业提交阶段就报错

## 测试

新增 `RecallEngineClientWriteTest`，11 个用例：满批在调用线程写出、500 行切成 200/200/100、按表和 insert mode 分组、5xx/429/传输失败重试、4xx 不重试、`retryTimes=0` 仍发一次、失败批次不留在缓冲区、定时器兜底写出残批、`close()` 兜底 flush。

删掉两个前提已被推翻的旧测试：`testWriteFlushDoesNotBlockProducers`（现在**故意**阻塞生产者，那就是反压）和 `testWriteExecutorIsHardened`（executor 没了）。

全量 62 个测试，1 个失败：`testRecall` —— 打真实服务返回 `get recall manager login info failed, 404`。已在改动前的代码上验证过同样失败，是环境/凭证问题，与本次改动无关。

## 已知未处理

- `close()` 的 `join()` 无超时 + `writeFlush()` 带重试，后端卡死时会拖久，可能撞 Flink 的 cancel timeout。这是 9fa3373 刻意的取舍，加回超时等于重新引入停作业丢数据
- `write()` 与 `close()` 跨线程竞态会丢一行。Flink 里两者同一个 task 线程，触发不了
- `recall()` 的重试仍是老语义（`retryTimes=1` 等于不重试、4xx 也重试），不在本次范围

🤖 Generated with [Claude Code](https://claude.com/claude-code)